### PR TITLE
Added support for most common compressed archives using  7z utility

### DIFF
--- a/lib/IO/Path/AutoDecompress.rakumod
+++ b/lib/IO/Path/AutoDecompress.rakumod
@@ -13,6 +13,10 @@ class IO::Path::AutoDecompress is IO::Path {
             my $proc := run <bunzip2 --stdout>, self, :out;
             $proc.out.lines(:$chomp, :$enc, :$nl-in)
         }
+        elsif $extension ~~ /^(zip|rar|7z|xz)$/ {
+            my $proc := run <7z e -so>, self, :out;
+            $proc.out.lines(:$chomp, :$enc, :$nl-in)
+        }
         else {
             self.IO::Path::lines(:$chomp, :$enc, :$nl-in)
         }


### PR DESCRIPTION
As discussed I've added support for zip,rar,7z,xz which work identically as for gz & bzip2 if p7zip is installed.